### PR TITLE
add aarch64 cross compile

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -90,10 +90,24 @@ jobs:
           mkdir dist
           cp ./out/Release/libnodev2.so dist/libnodev2.so
 
+      - name: Build aarch64
+        run: |
+          sudo apt-get install cmake build-essential binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3 make python3-pip
+          chmod +rwx alt-release-aarch64.sh
+          cd alt-build && bash alt-release-aarch64.sh
+          cd ..
+          mkdir dist_aarch64
+          cp ./out/Release/libnodev2.so dist_aarch64/libnodev2.so
+
       - uses: actions/upload-artifact@v3
         with:
           name: node-linux-release
           path: ./dist/
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: node-linux-release-aarch64
+          path: ./dist_aarch64/
 
   deploy:
     name: Deploy
@@ -121,11 +135,18 @@ jobs:
           name: node-linux-release
           path: dist-linux-release
 
+      - name: Download linux aarch64 release artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: node-linux-release-aarch64
+          path: dist-linux-release-aarch64
+
       - name: Zip artifacts
         run: |
           zip -r -j node-windows-release dist-windows-release
           zip -r -j node-windows-debug dist-windows-debug
           zip -r -j node-linux-release dist-linux-release
+          zip -r -j node-linux-release-aarch64 dist-linux-release-aarch64
 
       - name: Create Release
         id: create_release
@@ -166,6 +187,16 @@ jobs:
           asset_name: node-linux-release.zip
           asset_content_type: application/zip
 
+      - name: Upload linux aarch64 release artifacts
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./node-linux-release-aarch64.zip
+          asset_name: node-linux-release-aarch64.zip
+          asset_content_type: application/zip
+
       - name: Extract version
         id: version
         shell: bash
@@ -201,6 +232,14 @@ jobs:
           BRANCH: ${{ steps.version.outputs.BRANCH }}
           VERSION: ${{ steps.version.outputs.VERSION }}
 
+      - name: Upload linux aarch64 files to CDN
+        run: npx alt-upload dist-linux-release-aarch64 deps/nodejs/v2/$BRANCH/aarch64_linux $VERSION
+        env:
+          CI_UPLOAD_URL: ${{ secrets.CI_UPLOAD_URL }}
+          CI_DEPLOY_TOKEN: ${{ secrets.CI_DEPLOY_TOKEN }}
+          BRANCH: ${{ steps.version.outputs.BRANCH }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+
   delete-artifacts:
     name: Delete artifacts
     runs-on: ubuntu-20.04
@@ -214,3 +253,4 @@ jobs:
             node-windows-release
             node-windows-debug
             node-linux-release
+            node-linux-release-aarch64

--- a/alt-build/alt-release-aarch64.sh
+++ b/alt-build/alt-release-aarch64.sh
@@ -1,0 +1,17 @@
+cd ..
+make clean
+touch ./deps/base64/base64/lib/config.h
+
+# Not all of these may be required, but I suppose it can't hurt to have them...
+export LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib
+export TOOLCHAIN_ROOT=/usr/aarch64-linux-gnu
+export AR=aarch64-linux-gnu-ar
+export CC=aarch64-linux-gnu-gcc
+export CXX=aarch64-linux-gnu-g++
+export LINK=aarch64-linux-gnu-g++
+export CC_host="aarch64-linux-gnu-gcc"
+export CXX_host="aarch64-linux-gnu-g++"
+
+./configure --shared --dest-cpu=arm64 --cross-compiling --dest-os=linux --with-arm-float-abi=hard --with-arm-fpu=neon
+make -j$(nproc)
+cd alt-build


### PR DESCRIPTION
Updated workflow and added script for aarch64 cross compiling.

Not 100% sure if I added all the workflow steps correctly, but if not let me know and I'll update it :)

Completely untested. Although verified with ``file`` command to confirm the final file is targeted for aarch64:

```shell
root@756b69d25f8d:/opt/alt-node/out/Release# ls
bytecode_builtins_list_generator  cctest  embedtest  gen-regexp-special-case  genccode  icupkg  libnodev2.so  mksnapshot  node  node_mksnapshot  obj  obj.host  obj.target  openssl-cli  overlapped-checker  torque
root@756b69d25f8d:/opt/alt-node/out/Release# file libnodev2.so 
libnodev2.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (GNU/Linux), dynamically linked, BuildID[sha1]=c5d7d14a40bbca0c1de862cc8b5bb0b5f3cf12fc, with debug_info, not stripped
root@756b69d25f8d:/opt/alt-node/out/Release#
```

Was also able to compile libjs-module.so for aarch64 with this one (I'll open a PR on that project if ya'll are interested in enabling aarch64 builds):
```shell
root@756b69d25f8d:/opt/altv-js-module/server# cd dist-aarch64/
root@756b69d25f8d:/opt/altv-js-module/server/dist-aarch64# ls
libjs-module.so
root@756b69d25f8d:/opt/altv-js-module/server/dist-aarch64# file libjs-module.so 
libjs-module.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (GNU/Linux), dynamically linked, BuildID[sha1]=f5eacdc053011ec8ab713b4170cb70e2f8048548, not stripped
root@756b69d25f8d:/opt/altv-js-module/server/dist-aarch64
```